### PR TITLE
added cprofile logic to the coach code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,8 @@ filtered.txt
 unfiltered.txt
 *.csv
 
+# profiling data files
+*.prof
+
 # Config custom
 *.custom.cfg

--- a/Engine/Framework.py
+++ b/Engine/Framework.py
@@ -45,6 +45,8 @@ class Framework:
         if cli_args.unlock_engine_fps:
             self.engine.unlock_fps()
 
+        self.profiling_enabled = cli_args.enable_profiling
+
         self.engine.start()
 
         # AI
@@ -53,7 +55,8 @@ class Framework:
                            self.ai_queue,
                            self.referee_queue,
                            self.ui_send_queue,
-                           self.ui_recv_queue)
+                           self.ui_recv_queue,
+                           self.profiling_enabled)
         self.coach.start()
 
         # end signal - do you like to stop gracefully? DO NOT MOVE! MUST BE PLACED AFTER PROCESSES

--- a/ai/coach.py
+++ b/ai/coach.py
@@ -16,7 +16,7 @@ from ai.states.game_state import GameState
 from ai.states.play_state import PlayState
 from config.config import Config
 
-PROFILE_AI = True
+AI_CPROFILING_ENABLED = True
 PROFILE_DATA_TICK_NUMBER = 100
 PROFILE_DATA_FILENAME = 'profile_data_ai.prof'
 
@@ -71,7 +71,7 @@ class Coach(Process):
     def run(self) -> None:
         self.wait_for_geometry()
         self.logger.debug('Running with process ID {}'.format(os.getpid()))
-        if PROFILE_AI:
+        if AI_CPROFILING_ENABLED:
             self.pr = cProfile.Profile()
             self.pr.enable()
         cycle_tick_count = 0
@@ -83,13 +83,11 @@ class Coach(Process):
                 cycle_tick_count += 1
                 if cycle_tick_count == PROFILE_DATA_TICK_NUMBER:
                     cycle_tick_count = 0
-                    if PROFILE_AI:
+                    if AI_CPROFILING_ENABLED:
                         self.pr.dump_stats(PROFILE_DATA_FILENAME)
-                        print('ai profile data written.')
+                        self.logger.debug('ai profile data written.')
 
         except KeyboardInterrupt:
-            self.pr.dump_stats(PROFILE_DATA_FILENAME)
-            print('ai profile data written during keyboard interrupt.')
             pass
 
     def main_loop(self) -> None:

--- a/ai/coach.py
+++ b/ai/coach.py
@@ -16,7 +16,6 @@ from ai.states.game_state import GameState
 from ai.states.play_state import PlayState
 from config.config import Config
 
-AI_CPROFILING_ENABLED = True
 PROFILE_DATA_TICK_NUMBER = 100
 PROFILE_DATA_FILENAME = 'profile_data_ai.prof'
 
@@ -28,7 +27,8 @@ class Coach(Process):
                  ai_queue: Queue,
                  referee_queue: Queue,
                  ui_send_queue: Queue,
-                 ui_recv_queue: Queue):
+                 ui_recv_queue: Queue,
+                 profiling_enabled=False):
 
         super().__init__(name=__name__)
 
@@ -60,6 +60,7 @@ class Coach(Process):
         # print frame rate
         self.frame_count = 0
         self.time_last_print = time()
+        self.profiling_enabled = profiling_enabled
 
     def wait_for_geometry(self):
         self.logger.debug('Waiting for geometry from the Engine.')
@@ -71,7 +72,7 @@ class Coach(Process):
     def run(self) -> None:
         self.wait_for_geometry()
         self.logger.debug('Running with process ID {}'.format(os.getpid()))
-        if AI_CPROFILING_ENABLED:
+        if self.profiling_enabled:
             self.pr = cProfile.Profile()
             self.pr.enable()
         cycle_tick_count = 0
@@ -83,7 +84,7 @@ class Coach(Process):
                 cycle_tick_count += 1
                 if cycle_tick_count == PROFILE_DATA_TICK_NUMBER:
                     cycle_tick_count = 0
-                    if AI_CPROFILING_ENABLED:
+                    if self.profiling_enabled:
                         self.pr.dump_stats(PROFILE_DATA_FILENAME)
                         self.logger.debug('ai profile data written.')
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,11 @@ def set_arg_parser():
                             help='Flag when we are on the negative x side of the field.',
                             default=False)
 
+    arg_parser.add_argument('--enable_profiling',
+                            action='store_true',
+                            help='Enables profiling options through the project.',
+                            default=False)
+
     return arg_parser
 
 

--- a/showprofileinfo.py
+++ b/showprofileinfo.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+# usage: ./showprofileinfo.py NAMEOFPROFILINGDATAFILE
+
+if __name__ == "__main__":
+    import sys
+    import pstats
+    stats = pstats.Stats(sys.argv[1])
+    stats.strip_dirs()
+    stats.sort_stats('cumulative')
+    stats.print_stats()


### PR DESCRIPTION
- Can be turned off via a constant variable
- Comes with an helper script to read the profiling data file
- Called in the right process (the one that does the bulk of the computing)

Note: this cannot be dealt with in the start and __del__ methods because they are called as an object in a different process (the caller process), thus creating mostly useless data in that case, hence why they are placed around the loop code.

Some simple tick count code was added to prevent having to write the profiling data often, it does so every 3-4 seconds on my computer with the current tick count constant value.